### PR TITLE
fix: アライメントボディのフォーマットをオブジェクト形式に統一

### DIFF
--- a/content/page-interceptor.js
+++ b/content/page-interceptor.js
@@ -39,7 +39,9 @@
       } else if (existing && typeof existing === 'object' && Object.keys(existing).length > 0) {
         ids.forEach(id => { body.alignment[lang][id] = 1; });
       } else {
-        body.alignment[lang] = ids;
+        const obj = {};
+        ids.forEach(id => { obj[id] = 1; });
+        body.alignment[lang] = obj;
       }
 
       clearPendingIds();


### PR DESCRIPTION
## Summary

Closes #3

- `patchBody()` でアライメントIDが `null` / 未設定の場合、誤って配列形式 `[id]` で送信していた
- OBFは `{id: 1}` のオブジェクト形式を期待しているため、既存アライメントがない状態でバッジを保存するとアライメントが反映されない不具合があった
- 全ケースで `{id: 1}` 形式のオブジェクトに統一して送信するよう修正

## Test plan

- [ ] CASEピッカーからアイテムを選択 → バッジを保存 → アライメントが反映されていることを確認
- [ ] バッジに既存アライメントがある場合も同様に確認
- [ ] バッジに既存アライメントがない場合も同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)