### PR TITLE
docs: OBv3 CASE対応との差異・制約をドキュメントに明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,42 @@ MutationObserver + setInterval(800ms) の二重監視で継続的に再挿入す
 ## 未対応事項
 - 複数CASEフレームワーク対応（現在は高等学校学習指導要領のみ固定）
 - アライメント一覧・新規作成ページへの機能追加
+
+## 現実装の制約：OBv3 CASE対応との差異
+
+本実装は OBF の既存アライメント登録 UI をハックしているものであり、
+Open Badges 3.0 が規定する正式な CASE 対応（`targetFramework` 等）とは異なる。
+
+### OBF が使用しているアライメントスキーマ（Open Badges 2.0）
+
+| OBF フォームフィールド | 種別 | 本実装でのセット値 |
+|---|---|---|
+| `name` | テキスト（必須） | `CFItem.fullStatement`（例: "国語"）|
+| `url` | テキスト（必須） | `https://opensalt.net/uri/{CFItem.identifier}`（※後述）|
+| `description` | テキストエリア | `CFItem.notes`（空なら `CFItem.CFItemType`）|
+| `framework` | hidden | **空**（後述の理由によりセットしていない）|
+| `code` | hidden | **空**（後述の理由によりセットしていない）|
+
+### OBv3 の正式な Alignment オブジェクトとの比較
+
+Open Badges 3.0 では Alignment に以下のフィールドが定義されているが、
+現在の OBF は OB 2.0 ベースのため、これらのフィールドは存在しない。
+
+| OBv3 フィールド | CASE での対応値 | OBF での現状 |
+|---|---|---|
+| `targetName` | `CFItem.fullStatement` | `name` フィールドで代替 |
+| `targetUrl` | `CFItem.uri` | `url` フィールドで代替 |
+| `targetDescription` | `CFItem.notes` | `description` フィールドで代替 |
+| `targetFramework` | `CFDocument.title` | **未対応**（OBF に該当フィールドなし）|
+| `targetCode` | `CFItem.humanCodingScheme` | **未対応**（`code` hidden フィールドは内部ID期待のため空）|
+| `targetType` | `"CFItem"` | **未対応** |
+
+### 補足
+
+- **`url` の値について**: `CFItem.uri`（`satchel.commongoodlt.com`）は実証環境では無効なため、
+  `identifier` から `https://opensalt.net/uri/{identifier}` を手動で組み立てている。
+- **`framework` / `code` が空の理由**: OBF の `framework` hidden フィールドは自由テキストではなく
+  内部ID（もしくは特定の形式）を期待している可能性があり、自由テキストを入れるとバリデーションエラーになる。
+  OBF への問い合わせが解決するまで空で送信している。
+- 本実装は OBF の正式APIが存在しないための暫定ハックである。
+  将来 OBF が OBv3 + CASE に正式対応した場合、実装の大幅な見直しが必要になる。

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ obf-case-sample-extension/
 
 See [CLAUDE.md](./CLAUDE.md) for full technical details.
 
+## Limitations
+
+**This extension is a workaround, not a standards-compliant CASE integration.**
+
+OBF currently implements the Open Badges **2.0** alignment schema. The CASE-specific fields defined in Open Badges **3.0** (`targetFramework`, `targetCode`, `targetType`, etc.) are not supported by OBF. As a result, CASE data is mapped to the available OB 2.0 fields as follows:
+
+| OBF field | What is stored | OBv3 equivalent |
+|---|---|---|
+| `name` | `CFItem.fullStatement` | `targetName` |
+| `url` | `https://opensalt.net/uri/{identifier}` | `targetUrl` |
+| `description` | `CFItem.notes` or `CFItem.CFItemType` | `targetDescription` |
+| `framework` | *(empty — OBF validation issue)* | `targetFramework` |
+| `code` | *(empty — OBF validation issue)* | `targetCode` |
+
+`targetType: "CFItem"` and `targetFramework` have no corresponding field in OBF's current UI and are not stored.
+
+If OBF adds official OBv3 + CASE support in the future, this extension will need to be reworked accordingly.
+
 ## Customization
 
 To use a different CASE framework, update `CASE_ENDPOINT` in `background.js`:
@@ -113,6 +131,24 @@ obf-case-sample-extension/
 - アライメントの重複登録を防ぐため、OBF の既存アライメントをURLで2段階検索しています
 
 詳細は [CLAUDE.md](./CLAUDE.md) を参照してください。
+
+## 制約・注意事項
+
+**本拡張機能は暫定的な回避策であり、CASE の正式な標準実装ではありません。**
+
+OBF は現在 Open Badges **2.0** のアライメントスキーマを使用しています。Open Badges **3.0** で定義されている CASE 対応フィールド（`targetFramework`・`targetCode`・`targetType` 等）は OBF に存在しないため、CASE データを既存の OB 2.0 フィールドに次のように割り当てています。
+
+| OBF フィールド | セットされる値 | OBv3 での対応 |
+|---|---|---|
+| `name` | `CFItem.fullStatement`（例: "国語"）| `targetName` |
+| `url` | `https://opensalt.net/uri/{identifier}` | `targetUrl` |
+| `description` | `CFItem.notes` または `CFItem.CFItemType` | `targetDescription` |
+| `framework` | **空**（OBF のバリデーション制約のため）| `targetFramework` |
+| `code` | **空**（OBF のバリデーション制約のため）| `targetCode` |
+
+`targetType: "CFItem"` および `targetFramework` に相当するフィールドは OBF の現 UI に存在しないため、保存されません。
+
+将来 OBF が OBv3 + CASE に正式対応した場合、本拡張機能の大幅な見直しが必要になります。
 
 ## カスタマイズ
 


### PR DESCRIPTION
## Summary

- 現実装がOBFの既存アライメントUIへの暫定ハックであり、Open Badges 3.0が定義するCASE対応フィールド（`targetFramework`、`targetCode`、`targetType`等）には対応していないことを明記
- CASE → OBFフィールドのマッピング表を追加
- README.md（英語・日本語）と CLAUDE.md を更新

## Test plan

- [ ] README.md の英語セクション・日本語セクション両方にLimitationsが表示されること
- [ ] CLAUDE.md のフィールドマッピング表・補足が正確であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)